### PR TITLE
Fix detection on django 1.10+ for user warning

### DIFF
--- a/djstripe/__init__.py
+++ b/djstripe/__init__.py
@@ -1,7 +1,8 @@
 from __future__ import unicode_literals
 import warnings
 
-from django import get_version as get_django_version
+from django.utils.version import get_complete_version
+
 
 __title__ = "dj-stripe"
 __summary__ = "Django + Stripe Made Easy"
@@ -16,7 +17,7 @@ __license__ = "BSD"
 __license__ = "License :: OSI Approved :: BSD License"
 __copyright__ = "Copyright 2015 Daniel Greenfeld"
 
-if get_django_version() <= '1.7.x':
+if get_complete_version()[:2] <= (1, 7):
     msg = "dj-stripe deprecation notice: Django 1.7 and lower are no longer\n" \
         "supported. Please upgrade to Django 1.8 or higher.\n" \
         "Reference: https://github.com/pydanny/dj-stripe/issues/275"


### PR DESCRIPTION
This fixes the UserWarning when checking django version and django is 1.10+, by using integer comparison instead of alpha